### PR TITLE
use post request for state changing actions

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -110,7 +110,7 @@ document.addEventListener("turbolinks:load", function() {
   });
   $('.toggle-star').click(function() {
     $(this).toggleClass("star-active star-inactive");
-    $.get('/notifications/'+$(this).data('id')+'/star')
+    $.post('/notifications/'+$(this).data('id')+'/star')
   });
   $('.sync .octicon').on('click', function() {
     $(this).toggleClass('spinning')
@@ -211,7 +211,7 @@ function markReadSelected() {
 }
 
 function markRead(id) {
-  $.get( "/notifications/"+id+"/mark_read", function() {
+  $.post( "/notifications/"+id+"/mark_read").done(function() {
     updateFavicon();
   });
   $('#notification-'+id).removeClass('active');

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,8 +20,8 @@ Rails.application.routes.draw do
     end
 
     member do
-      get :star
-      get :mark_read
+      post :star
+      post :mark_read
     end
   end
 

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -182,7 +182,7 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
 
     sign_in_as(@user)
 
-    get "/notifications/#{notification.id}/star"
+    post "/notifications/#{notification.id}/star"
     assert_response :ok
 
     assert notification.reload.starred?
@@ -193,7 +193,7 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
 
     sign_in_as(@user)
 
-    get "/notifications/#{notification.id}/mark_read"
+    post "/notifications/#{notification.id}/mark_read"
     assert_response :ok
 
     refute notification.reload.unread?


### PR DESCRIPTION
Minor change use POST request for the DB state changing actions to prevent CSRF issues.

@jules2689 