### PR TITLE
Adding shipit.yml so we can deploy with ShipIt!

### DIFF
--- a/shipit.yml
+++ b/shipit.yml
@@ -1,0 +1,6 @@
+dependencies:
+  override: []
+
+deploy:
+  override:
+    - push-to-heroku shopify-octobox


### PR DESCRIPTION
Looks like https://shipit.shopify.io/shopify/octobox/production was partially setup. Adding required yml file for deployment.